### PR TITLE
Move `Result` handling to caller

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -46,7 +46,10 @@ pub async fn create_and_connect() -> SqlitePool {
     pool
 }
 
-pub async fn get_invitation_by_code(pool: &SqlitePool, code: &str) -> Option<Invitation> {
+pub async fn get_invitation_by_code(
+    pool: &SqlitePool,
+    code: &str,
+) -> Result<Option<Invitation>, sqlx::Error> {
     sqlx::query_as!(
         Invitation,
         r#"SELECT id, status, code, email FROM invitations WHERE code = ?"#,
@@ -54,5 +57,4 @@ pub async fn get_invitation_by_code(pool: &SqlitePool, code: &str) -> Option<Inv
     )
     .fetch_optional(pool)
     .await
-    .unwrap()
 }

--- a/src/routes/rsvp.rs
+++ b/src/routes/rsvp.rs
@@ -54,7 +54,7 @@ pub async fn route_handler(
 
     let invitation = db::get_invitation_by_code(&db.pool, &code).await;
 
-    if invitation.is_some() {
+    if let Ok(Some(_)) = invitation {
         session
             .insert(RSVP_STATUS_KEY, RsvpStatus { needs_code: false })
             .await


### PR DESCRIPTION
Moves the responsibility to handle the potential sqlx error to the caller