### PR TITLE
Add unknown invitation status to prevent panics

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -13,6 +13,7 @@ pub enum InvitationStatus {
     Pending,
     Accepted,
     Rejected,
+    Unknown,
 }
 
 impl From<String> for InvitationStatus {
@@ -21,7 +22,7 @@ impl From<String> for InvitationStatus {
             "Pending" => InvitationStatus::Pending,
             "Accepted" => InvitationStatus::Accepted,
             "Rejected" => InvitationStatus::Rejected,
-            _ => panic!("Invalid invitation status"),
+            _ => InvitationStatus::Unknown,
         }
     }
 }


### PR DESCRIPTION
Adds an extra invitation status enumeration to prevent panicing the application in case any mismatch between the database enum or the Rust enum might occur.